### PR TITLE
fix: use hardcoded action paths instead of dynamic uses

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,16 +40,6 @@ on:
         required: false
         default: 'hatlabs/apt.hatlabs.fi'
         type: string
-      test-action:
-        description: 'Path to the test action'
-        required: false
-        default: './.github/actions/run-tests'
-        type: string
-      build-action:
-        description: 'Path to the build action'
-        required: false
-        default: './.github/actions/build-deb'
-        type: string
       version-file:
         description: 'Path to VERSION file'
         required: false
@@ -92,7 +82,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run tests
-        uses: ${{ inputs.test-action }}
+        uses: ./.github/actions/run-tests
 
   build-and-release:
     needs: [test]
@@ -225,7 +215,7 @@ jobs:
 
       - name: Build .deb package
         if: steps.check.outputs.action == 'create'
-        uses: ${{ inputs.build-action }}
+        uses: ./.github/actions/build-deb
 
       - name: Rename package with distro+component suffix
         if: steps.check.outputs.action == 'create'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,18 +2,16 @@
 # Called by: repo/.github/workflows/pr.yml
 #
 # This workflow runs tests on pull requests using the caller repo's
-# local test action.
+# local test action at .github/actions/run-tests.
+#
+# Requirements:
+# - Caller repo must have .github/actions/run-tests/action.yml
 
 name: PR Checks
 
 on:
   workflow_call:
     inputs:
-      test-action:
-        description: 'Path to the test action (relative to repo root)'
-        required: false
-        default: './.github/actions/run-tests'
-        type: string
       runs-on:
         description: 'Runner to use'
         required: false
@@ -31,4 +29,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run tests
-        uses: ${{ inputs.test-action }}
+        uses: ./.github/actions/run-tests

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ jobs:
 **Inputs:**
 | Input | Default | Description |
 |-------|---------|-------------|
-| `test-action` | `./.github/actions/run-tests` | Path to test action |
 | `runs-on` | `ubuntu-latest` | Runner to use |
+
+**Required local action**: `.github/actions/run-tests/action.yml`
 
 ### build-release.yml
 
@@ -65,12 +66,14 @@ jobs:
 | `apt-distro` | `trixie` | APT distribution |
 | `apt-component` | `main` | APT component |
 | `apt-repository` | `hatlabs/apt.hatlabs.fi` | APT repo to dispatch to |
-| `test-action` | `./.github/actions/run-tests` | Path to test action |
-| `build-action` | `./.github/actions/build-deb` | Path to build action |
 | `version-file` | `VERSION` | Path to version file |
 | `maintainer-name` | `Hat Labs` | Changelog maintainer |
 | `maintainer-email` | `info@hatlabs.fi` | Changelog email |
 | `skip-tests` | `false` | Skip test job |
+
+**Required local actions** (hardcoded paths):
+- `.github/actions/run-tests/action.yml` - Test action
+- `.github/actions/build-deb/action.yml` - Build action
 
 **Secrets:**
 | Secret | Description |


### PR DESCRIPTION
## Summary

GitHub Actions doesn't support dynamic values in `uses:` fields. This PR replaces input-based action paths with hardcoded standard paths.

## Problem

The original implementation used:
```yaml
uses: ${{ inputs.test-action }}
uses: ${{ inputs.build-action }}
```

This fails with error:
> Unrecognized named-value: 'inputs'. Located at position 1 within expression: inputs.test-action

## Solution

Replace with hardcoded paths:
```yaml
uses: ./.github/actions/run-tests
uses: ./.github/actions/build-deb
```

Caller repos must provide these actions at the expected paths (which is already the convention).

## Test plan

- [ ] Merge this PR
- [ ] Re-run cockpit-apt PR #107 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)