### PR TITLE
feat: support local script overrides for multi-package repos

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -149,38 +149,49 @@ jobs:
         run: |
           UPSTREAM="${{ steps.version.outputs.upstream }}"
           REVISION="${{ steps.revision.outputs.revision }}"
-          DEBIAN_VERSION="${UPSTREAM}-${REVISION}"
-          DISTRIBUTION="unstable"
-          URGENCY="medium"
-          DATE=$(date -R)
 
-          # Get recent changes from git log
-          LAST_TAG=$(git tag -l "v*" --sort=-version:refname | grep -v "_pre" | head -n1 || echo "")
-
-          if [ -n "$LAST_TAG" ]; then
-            CHANGES=$(git log "${LAST_TAG}"..HEAD --pretty=format:"  * %s" --no-merges -- || echo "  * Build ${REVISION}")
+          # Check for local script override
+          if [ -f ".github/scripts/generate-changelog.sh" ]; then
+            echo "Using local generate-changelog.sh script"
+            .github/scripts/generate-changelog.sh \
+              --upstream "$UPSTREAM" \
+              --revision "$REVISION"
           else
-            CHANGES=$(git log -10 --pretty=format:"  * %s" --no-merges || echo "  * Build ${REVISION}")
-          fi
+            # Default: single package with debian/ at root
+            echo "Using default changelog generation"
+            DEBIAN_VERSION="${UPSTREAM}-${REVISION}"
+            DISTRIBUTION="unstable"
+            URGENCY="medium"
+            DATE=$(date -R)
 
-          if [ -z "$CHANGES" ]; then
-            CHANGES="  * Build ${REVISION}"
-          fi
+            # Get recent changes from git log
+            LAST_TAG=$(git tag -l "v*" --sort=-version:refname | grep -v "_pre" | head -n1 || echo "")
 
-          # Generate debian/changelog entry
-          cat > debian/changelog <<EOF
+            if [ -n "$LAST_TAG" ]; then
+              CHANGES=$(git log "${LAST_TAG}"..HEAD --pretty=format:"  * %s" --no-merges -- || echo "  * Build ${REVISION}")
+            else
+              CHANGES=$(git log -10 --pretty=format:"  * %s" --no-merges || echo "  * Build ${REVISION}")
+            fi
+
+            if [ -z "$CHANGES" ]; then
+              CHANGES="  * Build ${REVISION}"
+            fi
+
+            # Generate debian/changelog entry
+            cat > debian/changelog <<CHANGELOG_EOF
           ${{ inputs.package-name }} (${DEBIAN_VERSION}) ${DISTRIBUTION}; urgency=${URGENCY}
 
           ${CHANGES}
 
            -- ${{ inputs.maintainer-name }} <${{ inputs.maintainer-email }}>  ${DATE}
-          EOF
+          CHANGELOG_EOF
 
-          # Remove leading whitespace from heredoc
-          sed -i 's/^          //' debian/changelog
+            # Remove leading whitespace from heredoc
+            sed -i 's/^          //' debian/changelog
 
-          echo "Generated debian/changelog:"
-          cat debian/changelog
+            echo "Generated debian/changelog:"
+            cat debian/changelog
+          fi
 
       - name: Set version variables
         id: versions
@@ -217,22 +228,33 @@ jobs:
         if: steps.check.outputs.action == 'create'
         uses: ./.github/actions/build-deb
 
-      - name: Rename package with distro+component suffix
+      - name: Rename packages with distro+component suffix
         if: steps.check.outputs.action == 'create'
         run: |
           DEBIAN_VERSION="${{ steps.versions.outputs.debian_version }}"
-          OLD_NAME="${PACKAGE_NAME}_${DEBIAN_VERSION}_all.deb"
-          NEW_NAME="${PACKAGE_NAME}_${DEBIAN_VERSION}_all+${APT_DISTRO}+${APT_COMPONENT}.deb"
 
-          if [ -f "$OLD_NAME" ]; then
-            echo "Renaming package: $(basename $OLD_NAME) -> $(basename $NEW_NAME)"
-            mv "$OLD_NAME" "$NEW_NAME"
-            echo "Package renamed successfully"
+          # Check for local script override
+          if [ -f ".github/scripts/rename-packages.sh" ]; then
+            echo "Using local rename-packages.sh script"
+            .github/scripts/rename-packages.sh \
+              --version "$DEBIAN_VERSION" \
+              --distro "$APT_DISTRO" \
+              --component "$APT_COMPONENT"
           else
-            echo "Error: Expected package not found: $OLD_NAME"
-            echo "Available .deb files:"
-            ls -la *.deb 2>/dev/null || echo "None found"
-            exit 1
+            # Default: single package
+            OLD_NAME="${PACKAGE_NAME}_${DEBIAN_VERSION}_all.deb"
+            NEW_NAME="${PACKAGE_NAME}_${DEBIAN_VERSION}_all+${APT_DISTRO}+${APT_COMPONENT}.deb"
+
+            if [ -f "$OLD_NAME" ]; then
+              echo "Renaming package: $(basename $OLD_NAME) -> $(basename $NEW_NAME)"
+              mv "$OLD_NAME" "$NEW_NAME"
+              echo "Package renamed successfully"
+            else
+              echo "Error: Expected package not found: $OLD_NAME"
+              echo "Available .deb files:"
+              ls -la *.deb 2>/dev/null || echo "None found"
+              exit 1
+            fi
           fi
 
       - name: Generate pre-release notes
@@ -240,19 +262,29 @@ jobs:
         run: |
           DEBIAN_VERSION="${{ steps.versions.outputs.debian_version }}"
           TAG_VERSION="${{ steps.versions.outputs.prerelease_tag }}"
-          SHORT_SHA="${GITHUB_SHA:0:7}"
 
-          # Get changelog since last published release
-          LAST_TAG=$(gh release list --limit 100 --json tagName,isPrerelease,isDraft \
-            --jq '.[] | select(.isDraft == false and .isPrerelease == false) | .tagName' | head -n1 || true)
-
-          if [ -n "$LAST_TAG" ]; then
-            CHANGELOG=$(git log "${LAST_TAG}"..HEAD --pretty=format:"- %s (%h)" --no-merges -- || echo "- Build ${DEBIAN_VERSION}")
+          # Check for local script override
+          if [ -f ".github/scripts/generate-release-notes.sh" ]; then
+            echo "Using local generate-release-notes.sh script"
+            .github/scripts/generate-release-notes.sh \
+              "$DEBIAN_VERSION" \
+              "$TAG_VERSION" \
+              prerelease
           else
-            CHANGELOG=$(git log -10 --pretty=format:"- %s (%h)" --no-merges)
-          fi
+            # Default release notes
+            SHORT_SHA="${GITHUB_SHA:0:7}"
 
-          cat > release_notes.md <<EOF
+            # Get changelog since last published release
+            LAST_TAG=$(gh release list --limit 100 --json tagName,isPrerelease,isDraft \
+              --jq '.[] | select(.isDraft == false and .isPrerelease == false) | .tagName' | head -n1 || true)
+
+            if [ -n "$LAST_TAG" ]; then
+              CHANGELOG=$(git log "${LAST_TAG}"..HEAD --pretty=format:"- %s (%h)" --no-merges -- || echo "- Build ${DEBIAN_VERSION}")
+            else
+              CHANGELOG=$(git log -10 --pretty=format:"- %s (%h)" --no-merges)
+            fi
+
+            cat > release_notes.md <<NOTES_EOF
           ## ${{ inputs.package-name }} ${TAG_VERSION} (Pre-release)
 
           > **This is a pre-release build from the main branch. Use for testing only.**
@@ -280,10 +312,11 @@ jobs:
           sudo apt update
           sudo apt install ${{ inputs.package-name }}
           \`\`\`
-          EOF
+          NOTES_EOF
 
-          # Remove leading whitespace from heredoc
-          sed -i 's/^          //' release_notes.md
+            # Remove leading whitespace from heredoc
+            sed -i 's/^          //' release_notes.md
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -309,18 +342,28 @@ jobs:
         if: steps.check.outputs.action == 'create'
         run: |
           DEBIAN_VERSION="${{ steps.versions.outputs.debian_version }}"
+          STABLE_TAG="${{ steps.versions.outputs.stable_tag }}"
 
-          # Get changelog since last published release
-          LAST_TAG=$(gh release list --limit 100 --json tagName,isPrerelease,isDraft \
-            --jq '.[] | select(.isDraft == false and .isPrerelease == false) | .tagName' | head -n1 || true)
-
-          if [ -n "$LAST_TAG" ]; then
-            CHANGELOG=$(git log "${LAST_TAG}"..HEAD --pretty=format:"- %s (%h)" --no-merges -- || echo "- Release ${DEBIAN_VERSION}")
+          # Check for local script override
+          if [ -f ".github/scripts/generate-release-notes.sh" ]; then
+            echo "Using local generate-release-notes.sh script"
+            .github/scripts/generate-release-notes.sh \
+              "$DEBIAN_VERSION" \
+              "$STABLE_TAG" \
+              draft
           else
-            CHANGELOG=$(git log -10 --pretty=format:"- %s (%h)" --no-merges)
-          fi
+            # Default release notes
+            # Get changelog since last published release
+            LAST_TAG=$(gh release list --limit 100 --json tagName,isPrerelease,isDraft \
+              --jq '.[] | select(.isDraft == false and .isPrerelease == false) | .tagName' | head -n1 || true)
 
-          cat > release_notes.md <<EOF
+            if [ -n "$LAST_TAG" ]; then
+              CHANGELOG=$(git log "${LAST_TAG}"..HEAD --pretty=format:"- %s (%h)" --no-merges -- || echo "- Release ${DEBIAN_VERSION}")
+            else
+              CHANGELOG=$(git log -10 --pretty=format:"- %s (%h)" --no-merges)
+            fi
+
+            cat > release_notes.md <<NOTES_EOF
           ## ${{ inputs.package-name }} v${DEBIAN_VERSION}
 
           ${{ inputs.package-description }}
@@ -337,10 +380,11 @@ jobs:
           sudo apt update
           sudo apt install ${{ inputs.package-name }}
           \`\`\`
-          EOF
+          NOTES_EOF
 
-          # Remove leading whitespace from heredoc
-          sed -i 's/^          //' release_notes.md
+            # Remove leading whitespace from heredoc
+            sed -i 's/^          //' release_notes.md
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ jobs:
 - `.github/actions/run-tests/action.yml` - Test action
 - `.github/actions/build-deb/action.yml` - Build action
 
+**Optional local script overrides** (for multi-package or custom repos):
+- `.github/scripts/generate-changelog.sh` - Custom changelog generation
+- `.github/scripts/rename-packages.sh` - Custom package renaming
+- `.github/scripts/generate-release-notes.sh` - Custom release notes
+
+If these scripts exist, they will be called instead of the default inlined logic.
+See [Local Script Overrides](#local-script-overrides) for details.
+
 **Secrets:**
 | Secret | Description |
 |--------|-------------|
@@ -193,12 +201,52 @@ To migrate an existing repository:
 
 3. **Copy caller templates** from `examples/` and customize.
 
-4. **Remove old scripts** (now inlined in shared workflows):
-   - `.github/scripts/calculate-revision.sh`
-   - `.github/scripts/generate-changelog.sh`
-   - `.github/scripts/generate-release-notes.sh`
+4. **Scripts**: For simple single-package repos, you can remove old scripts (now inlined).
+   For multi-package repos, keep the scripts - they'll be used as overrides.
 
 5. **Test** with a PR before merging.
+
+## Local Script Overrides
+
+For repos with non-standard structures (e.g., multiple packages, subdirectories), provide local scripts that the shared workflow will call instead of the default inlined logic.
+
+### generate-changelog.sh
+
+Called with: `--upstream <version> --revision <N>`
+
+Example for multi-package repo:
+```bash
+#!/bin/bash
+# Generate changelogs for multiple packages
+for pkg in halos halos-marine; do
+  cat > ${pkg}/debian/changelog <<EOF
+${pkg} (${UPSTREAM}-${REVISION}) unstable; urgency=medium
+  * Build ${REVISION}
+ -- Maintainer <email>  $(date -R)
+EOF
+done
+```
+
+### rename-packages.sh
+
+Called with: `--version <debian-version> --distro <distro> --component <component>`
+
+Example:
+```bash
+#!/bin/bash
+# Rename multiple packages
+for pkg in halos halos-marine; do
+  OLD="${pkg}_${VERSION}_all.deb"
+  NEW="${pkg}_${VERSION}_all+${DISTRO}+${COMPONENT}.deb"
+  [ -f "$OLD" ] && mv "$OLD" "$NEW"
+done
+```
+
+### generate-release-notes.sh
+
+Called with: `<debian-version> <tag-version> <release-type>`
+
+Where `release-type` is `prerelease` or `draft`. Must write to `release_notes.md`.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Add optional local script override support for repos with non-standard structures.

## Problem

The inlined default logic assumes:
- Single package
- `debian/` at repo root

Repos like `halos-metapackages` have multiple packages in subdirectories.

## Solution

If these scripts exist in the caller repo, they're used instead of the default:

- `.github/scripts/generate-changelog.sh` - Custom changelog generation
- `.github/scripts/rename-packages.sh` - Custom package renaming
- `.github/scripts/generate-release-notes.sh` - Custom release notes

Simple single-package repos don't need any scripts - the defaults work.

## Test plan

- [x] cockpit-apt PR #107 passes (uses defaults)
- [ ] halos-metapackages can use shared workflows with local scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)