### PR TITLE
fix(ci): make apt-distro and apt-component required inputs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,14 +26,12 @@ on:
         default: 'Debian package'
         type: string
       apt-distro:
-        description: 'APT distribution (e.g., trixie, bookworm)'
-        required: false
-        default: 'trixie'
+        description: 'APT distribution (e.g., trixie, bookworm, any)'
+        required: true
         type: string
       apt-component:
-        description: 'APT component (e.g., main)'
-        required: false
-        default: 'main'
+        description: 'APT component (e.g., main, hatlabs)'
+        required: true
         type: string
       apt-repository:
         description: 'APT repository to dispatch to'

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -10,14 +10,12 @@ on:
   workflow_call:
     inputs:
       apt-distro:
-        description: 'APT distribution (e.g., trixie, bookworm)'
-        required: false
-        default: 'trixie'
+        description: 'APT distribution (e.g., trixie, bookworm, any)'
+        required: true
         type: string
       apt-component:
-        description: 'APT component (e.g., main)'
-        required: false
-        default: 'main'
+        description: 'APT component (e.g., main, hatlabs)'
+        required: true
         type: string
       apt-repository:
         description: 'APT repository to dispatch to'


### PR DESCRIPTION
## Summary
- Remove default values for `apt-distro` and `apt-component` inputs
- Make both inputs required in `build-release.yml` and `publish-stable.yml`

## Why
This prevents silent fallback to defaults which could cause packages to be deployed to incorrect distributions or components (e.g., the issue where HALPI2-rust-daemon stable release went to `trixie` instead of `any`).

## Prerequisites
All calling repositories have been updated to provide explicit values:
- hatlabs/HALPI2-daemon#50 - `apt-distro: any, apt-component: hatlabs`
- hatlabs/cockpit-apt#108 - `apt-distro: trixie, apt-component: main`
- hatlabs/halos-metapackages#6 - `apt-distro: trixie, apt-component: main`
- hatlabs/HALPI2-rust-daemon#87 - `apt-distro: any, apt-component: hatlabs`
- hatlabs/halos-marine-containers#30 - `apt-distro: trixie, apt-component: main`

**Merge order:** Merge all the above PRs first, then merge this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)