### PR TITLE
feat(build-release): delete previous draft releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -386,6 +386,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Delete previous draft releases
+        if: steps.check.outputs.action == 'create'
+        run: |
+          echo "Cleaning up previous draft releases..."
+          # List all draft releases and delete them
+          DRAFT_RELEASES=$(gh release list --json tagName,isDraft --jq '.[] | select(.isDraft == true) | .tagName')
+
+          if [ -z "$DRAFT_RELEASES" ]; then
+            echo "No draft releases to clean up"
+          else
+            while IFS= read -r tag; do
+              echo "Deleting draft release: $tag"
+              gh release delete "$tag" --yes
+            done <<< "$DRAFT_RELEASES"
+            echo "Draft releases cleaned up"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Create draft stable release
         if: steps.check.outputs.action == 'create'
         run: |


### PR DESCRIPTION
## Summary
- Add a step to delete previous draft releases before creating a new one
- Prevents accumulation of draft releases that were never published
- Keeps the releases page clean across all repos using the shared workflow

## Test plan
- [ ] Merge this PR to shared-workflows main
- [ ] Trigger a build in halos-marine-containers (can be done by making a small change)
- [ ] Verify that old draft releases are cleaned up before the new draft is created
- [ ] Check that pre-releases and published releases are NOT affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)