### PR TITLE
fix(build-release): add --limit to draft release deletion

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -391,7 +391,7 @@ jobs:
         run: |
           echo "Cleaning up previous draft releases..."
           # List all draft releases and delete them
-          DRAFT_RELEASES=$(gh release list --json tagName,isDraft --jq '.[] | select(.isDraft == true) | .tagName')
+          DRAFT_RELEASES=$(gh release list --limit 100 --json tagName,isDraft --jq '.[] | select(.isDraft == true) | .tagName')
 
           if [ -z "$DRAFT_RELEASES" ]; then
             echo "No draft releases to clean up"


### PR DESCRIPTION
## Summary

- Fix `gh release list` pagination issue in draft release deletion step

The `gh release list` command defaults to returning only 30 results. Repositories with many releases (like halos-marine-containers with 40+) would not see older draft releases beyond position 30, leaving them orphaned.

**Root cause**: halos-marine-containers had v0.1.0 draft releases (v0.1.0+1 through v0.1.0+4) that were never deleted because they were at positions 31+ in the release list.

**Fix**: Add `--limit 100` to ensure all draft releases are found and deleted.

## Test plan

- [ ] Merge this PR
- [ ] Trigger a main branch build on halos-marine-containers
- [ ] Verify the old v0.1.0 drafts are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)