### PR TITLE
feat(pr-checks): add lintian checks for Debian packages

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,6 +6,7 @@
 #
 # Requirements:
 # - Caller repo must have .github/actions/run-tests/action.yml
+# - For lintian checks: .github/actions/build-deb/action.yml (optional)
 
 name: PR Checks
 
@@ -17,6 +18,11 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+      skip-lintian:
+        description: 'Skip lintian checks (for repos without Debian packages)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -30,3 +36,51 @@ jobs:
 
       - name: Run tests
         uses: ./.github/actions/run-tests
+
+  lintian:
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.skip-lintian }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check if build-deb action exists
+        id: check-build-deb
+        run: |
+          if [ -f ".github/actions/build-deb/action.yml" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Debian package
+        if: steps.check-build-deb.outputs.exists == 'true'
+        uses: ./.github/actions/build-deb
+
+      - name: Install lintian
+        if: steps.check-build-deb.outputs.exists == 'true'
+        run: sudo apt-get update && sudo apt-get install -y lintian
+
+      - name: Run lintian
+        if: steps.check-build-deb.outputs.exists == 'true'
+        run: |
+          echo "Running lintian on built packages..."
+          failed=0
+          for deb in *.deb; do
+            if [ -f "$deb" ]; then
+              echo ""
+              echo "=== Checking: $deb ==="
+              # Run lintian with informational output, fail on errors and warnings
+              if ! lintian --info --display-info --fail-on error,warning "$deb"; then
+                failed=1
+              fi
+            fi
+          done
+          if [ $failed -eq 1 ]; then
+            echo ""
+            echo "❌ Lintian found issues. See above for details."
+            echo "To suppress specific tags, create debian/<package>.lintian-overrides"
+            exit 1
+          fi
+          echo ""
+          echo "✅ Lintian checks passed"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These workflows implement a standardized release process:
 
 ### pr-checks.yml
 
-Runs tests on pull requests.
+Runs tests and lintian checks on pull requests.
 
 ```yaml
 # .github/workflows/pr.yml
@@ -32,9 +32,22 @@ jobs:
 **Inputs:**
 | Input | Default | Description |
 |-------|---------|-------------|
-| `runs-on` | `ubuntu-latest` | Runner to use |
+| `runs-on` | `ubuntu-latest` | Runner to use for tests |
+| `skip-lintian` | `false` | Skip lintian checks |
+
+**Jobs:**
+1. **tests**: Runs `.github/actions/run-tests/action.yml`
+2. **lintian**: Builds package and runs lintian (if `.github/actions/build-deb/action.yml` exists)
+
+**Lintian Checks:**
+- Automatically runs if `.github/actions/build-deb/action.yml` exists
+- Fails on errors and warnings
+- To suppress specific tags, create `debian/<package>.lintian-overrides`
+- Set `skip-lintian: true` to disable
 
 **Required local action**: `.github/actions/run-tests/action.yml`
+
+**Optional local action**: `.github/actions/build-deb/action.yml` (enables lintian checks)
 
 ### build-release.yml
 


### PR DESCRIPTION
## Summary

- Add lintian job to PR checks workflow
- Automatically runs if repo has `.github/actions/build-deb/action.yml`
- Fails on lintian errors and warnings
- Can be disabled with `skip-lintian: true` input

## How it works

1. Checks if the calling repo has a `build-deb` action
2. If yes, builds the Debian package using that action
3. Runs `lintian --info --display-info --fail-on error,warning` on all `.deb` files
4. Fails the job if lintian finds errors or warnings

## Repos affected

All 11 repos that use the shared PR workflow and have `build-deb` actions will get lintian checks:
- cockpit-apt
- cockpit-authelia-users
- cockpit-container-apps
- cockpit-dockermanager-debian
- container-packaging-tools
- halos-cockpit-branding
- halos-homarr-branding
- halos-mdns-publisher
- homarr-container-adapter
- halos-metapackages
- HALPI2-rust-daemon

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test on a repo with simple native build (e.g., halos-cockpit-branding)
- [ ] Test on a repo with Docker-based build (e.g., cockpit-apt)
- [ ] Verify skip-lintian input works

🤖 Generated with [Claude Code](https://claude.com/claude-code)