### PR TITLE
feat: add version-check job to PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,6 +6,7 @@
 #
 # Requirements:
 # - Caller repo must have .github/actions/run-tests/action.yml
+# - For version checks: .github/actions/check-versions/action.yml (optional)
 # - For lintian checks: .github/actions/build-deb/action.yml (optional)
 
 name: PR Checks
@@ -38,7 +39,7 @@ jobs:
         uses: ./.github/actions/run-tests
 
   version-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,7 +47,7 @@ jobs:
       - name: Check if check-versions action exists
         id: check-action
         run: |
-          if [ -f ".github/actions/check-versions/action.yml" ]; then
+          if [ -f ".github/actions/check-versions/action.yml" ] || [ -f ".github/actions/check-versions/action.yaml" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Run tests
         uses: ./.github/actions/run-tests
 
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check if check-versions action exists
+        id: check-action
+        run: |
+          if [ -f ".github/actions/check-versions/action.yml" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check version consistency
+        if: steps.check-action.outputs.exists == 'true'
+        uses: ./.github/actions/check-versions
+
   lintian:
     runs-on: ubuntu-latest
     if: ${{ !inputs.skip-lintian }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ jobs:
 
 **Jobs:**
 1. **tests**: Runs `.github/actions/run-tests/action.yml`
-2. **lintian**: Builds package and runs lintian (if `.github/actions/build-deb/action.yml` exists)
+2. **version-check**: Runs `.github/actions/check-versions/action.yml` (if exists)
+3. **lintian**: Builds package and runs lintian (if `.github/actions/build-deb/action.yml` exists)
+
+**Version Checks:**
+- Automatically runs if `.github/actions/check-versions/action.yml` exists
+- Use to verify VERSION file stays in sync with language-specific version files
+- Each repo implements its own version checking logic
 
 **Lintian Checks:**
 - Automatically runs if `.github/actions/build-deb/action.yml` exists
@@ -47,7 +53,9 @@ jobs:
 
 **Required local action**: `.github/actions/run-tests/action.yml`
 
-**Optional local action**: `.github/actions/build-deb/action.yml` (enables lintian checks)
+**Optional local actions**:
+- `.github/actions/build-deb/action.yml` (enables lintian checks)
+- `.github/actions/check-versions/action.yml` (enables version consistency checks)
 
 ### build-release.yml
 


### PR DESCRIPTION
## Summary
- Adds optional `version-check` job to `pr-checks.yml`
- Runs `.github/actions/check-versions/action.yml` if it exists in the calling repo
- Each repo can implement their own version checking logic
- Repos without the action automatically skip the check

## Test plan
- [ ] Verify existing repos without `check-versions` action still pass PR checks
- [ ] Test with halos-mdns-publisher PR that adds `check-versions` action
- [ ] Test with cockpit-apt PR that adds `check-versions` action

🤖 Generated with [Claude Code](https://claude.com/claude-code)