### PR TITLE
fix(publish-stable): support 3-part and 4-part version numbers

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -22,11 +22,12 @@ on:
         required: false
         default: 'hatlabs/apt.hatlabs.fi'
         type: string
-      # Version tag format: v{upstream}+{revision} (e.g., v0.2.0+1)
+      # Version tag format: v{upstream}+{revision} (e.g., v0.2.0+1 or v1.0.7.2+1)
       version-pattern:
-        description: 'Regex pattern to validate version tags'
+        description: 'Regex pattern to validate version tags (must capture upstream and revision)'
         required: false
-        default: '^v([0-9]+\.[0-9]+\.[0-9]+)\+([0-9]+)$'
+        # Matches both 3-part (1.0.7) and 4-part (1.0.7.2) versions
+        default: '^v([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)\+([0-9]+)$'
         type: string
     secrets:
       APT_REPO_PAT:


### PR DESCRIPTION
## Summary

Update default `version-pattern` in `publish-stable.yml` to match both 3-part (1.0.7) and 4-part (1.0.7.2) version numbers.

## Problem

The previous default pattern only matched 3-part versions:
```
^v([0-9]+\.[0-9]+\.[0-9]+)\+([0-9]+)$
```

This caused publish failures for repos using 4-part versions (e.g., cockpit-dockermanager-debian with `v1.0.7.2+1`).

## Solution

Update default to accept both formats:
```
^v([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)\+([0-9]+)$
```

The `(?:\.[0-9]+)?` makes the 4th version part optional.

## Test plan

- [ ] Verify existing repos with 3-part versions still work
- [ ] Verify repos with 4-part versions now work without custom patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)