### PR TITLE
fix(publish-stable): use bash-compatible regex pattern

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -27,7 +27,9 @@ on:
         description: 'Regex pattern to validate version tags (must capture upstream and revision)'
         required: false
         # Matches both 3-part (1.0.7) and 4-part (1.0.7.2) versions
-        default: '^v([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)\+([0-9]+)$'
+        # Note: Uses capturing group instead of (?:) which bash =~ doesn't support
+        # BASH_REMATCH[1]=upstream, [2]=optional 4th part (unused), [3]=revision
+        default: '^v([0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?)\+([0-9]+)$'
         type: string
     secrets:
       APT_REPO_PAT:
@@ -53,7 +55,7 @@ jobs:
           PATTERN='${{ inputs.version-pattern }}'
           if [[ $STABLE_TAG =~ $PATTERN ]]; then
             UPSTREAM="${BASH_REMATCH[1]}"
-            REVISION="${BASH_REMATCH[2]}"
+            REVISION="${BASH_REMATCH[3]}"
 
             echo "upstream=$UPSTREAM" >> $GITHUB_OUTPUT
             echo "revision=$REVISION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Fix regex pattern that uses `(?:...)` non-capturing groups, which bash's `=~` operator doesn't support
- All stable releases were failing with "Tag format invalid" error

## Root Cause

The pattern `^v([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)\+([0-9]+)$` uses PCRE-style non-capturing groups `(?:...)` which are not part of POSIX Extended Regular Expressions (ERE) that bash uses.

## Fix

Changed to regular capturing group `(...)` and adjusted the BASH_REMATCH index from [2] to [3] to account for the additional capture group.

## Test plan

- [ ] Re-run failed halos-core-containers stable release
- [ ] Verify version extraction works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)