### PR TITLE
feat: add version bump enforcement check to PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,10 @@
 # - Caller repo must have .github/actions/run-tests/action.yml
 # - For version checks: .github/actions/check-versions/action.yml (optional)
 # - For lintian checks: .github/actions/build-deb/action.yml (optional)
+#
+# Version bump check:
+# - Requires VERSION file (repo-level) or apps/ directory (app-level)
+# - Automatically skipped for docs, tests, CI, and tooling changes
 
 name: PR Checks
 
@@ -104,3 +108,80 @@ jobs:
           fi
           echo ""
           echo "✅ Lintian checks passed"
+
+  version-bump-check:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if version bumps are needed
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          FAILED=0
+
+          git fetch origin "$BASE_REF" --depth=1
+
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No files changed"
+            exit 0
+          fi
+
+          # --- Part A: App-level version check ---
+          if [ -d "apps" ]; then
+            # Find app directories with changed non-metadata files
+            CHANGED_APP_DIRS=$(echo "$CHANGED_FILES" \
+              | grep -E '^apps/[^/]+/' \
+              | grep -v '/metadata\.yaml$' \
+              | sed 's|^\(apps/[^/]*\)/.*|\1|' \
+              | sort -u || true)
+
+            for app_dir in $CHANGED_APP_DIRS; do
+              if ! echo "$CHANGED_FILES" | grep -q "^${app_dir}/metadata\.yaml$"; then
+                echo "::error::${app_dir}/ was modified but ${app_dir}/metadata.yaml was not updated."
+                echo "  Bump the version field (e.g., 2.20.2-3 -> 2.20.2-4) in ${app_dir}/metadata.yaml"
+                FAILED=1
+              fi
+            done
+          fi
+
+          # --- Part B: Repo-level VERSION check ---
+          if [ -f "VERSION" ]; then
+            # Filter to non-app, package-affecting files (exclude docs, tests,
+            # CI config, dev tooling, and the VERSION file itself)
+            PACKAGE_FILES=$(echo "$CHANGED_FILES" \
+              | grep -v '^apps/' \
+              | grep -v -E '^(VERSION$|.*\.md$|docs/|\.github/|\.devcontainer/|\.vscode/|\.claude/)' \
+              | grep -v -E '^(lefthook\.yml$|\.bumpversion\.cfg$|\.gitignore$|\.editorconfig$|LICENSE)' \
+              | grep -v -E '^(tests?/|__tests__/|e2e/|.*\.test\.[^/]+$|.*\.spec\.[^/]+$)' \
+              | grep -v -E '^(docker/|Dockerfile|docker-compose)' \
+              | grep -v -E '^(tools/|run$|Makefile$|Taskfile\.yml$)' \
+              | grep -v -E '^(store/)' \
+              | grep -v -E '\.(lock)$' \
+              || true)
+
+            if [ -n "$PACKAGE_FILES" ]; then
+              if ! echo "$CHANGED_FILES" | grep -q '^VERSION$'; then
+                echo "::error::Package-affecting files changed but VERSION was not bumped."
+                echo ""
+                echo "Changed package files:"
+                echo "$PACKAGE_FILES" | sed 's/^/  /'
+                echo ""
+                echo "Run './run bumpversion patch' (or minor/major) to bump the version."
+                FAILED=1
+              fi
+            fi
+          fi
+
+          if [ $FAILED -eq 1 ]; then
+            exit 1
+          fi
+
+          echo "Version bump check passed"


### PR DESCRIPTION
## Summary

- Add `version-bump-check` job to `pr-checks.yml` that enforces version bumps in PRs
- **App-level check**: When files in `apps/<app>/` change, requires `apps/<app>/metadata.yaml` to also be modified
- **Repo-level check**: When package-affecting files change, requires `VERSION` file to be modified
- Automatically skipped for docs, tests, CI config, dev tooling, lock files, and other non-package files

## Context

Developers frequently forget to bump versions when creating PRs, resulting in follow-up PRs solely for version bumps. This check catches the oversight early.

All 12 repos that call `pr-checks.yml@main` will pick up the check automatically.

## Test plan

- [ ] Test with cockpit-apt: PR changing source without VERSION bump should fail
- [ ] Test with halos-marine-containers: PR changing `apps/*/docker-compose.yml` without `metadata.yaml` should fail
- [ ] Verify docs-only PR passes (no package-affecting files)
- [ ] Verify test-only PR passes (excluded by pattern)
- [ ] Verify `tools/` or `docker/` changes pass (excluded by pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)