### PR TITLE
fix: use workflow_ref instead of workflow_sha for script checkout

### DIFF
--- a/.github/workflows/check-image-updates.yml
+++ b/.github/workflows/check-image-updates.yml
@@ -39,11 +39,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # github.workflow_ref = "owner/repo/path@refs/heads/branch" — extract the ref
+      # after @ so the scripts checkout matches whichever version the caller pinned.
+      - name: Resolve shared workflow ref
+        id: wf-ref
+        run: echo "ref=${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+
       - name: Checkout shared scripts
         uses: actions/checkout@v4
         with:
           repository: hatlabs/shared-workflows
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.wf-ref.outputs.ref }}
           path: .shared-workflows
           sparse-checkout: scripts
 


### PR DESCRIPTION
## Summary

- `github.workflow_sha` resolves to the **caller** repo's commit, not the shared-workflows commit — causing `fatal: not our ref` when checking out scripts
- Parse the ref from `github.workflow_ref` instead (e.g., `...@refs/heads/main` -> `refs/heads/main`)
- This also correctly handles callers pinned to feature branches or tags

## Test plan

- [ ] Merge and re-run `check-updates` in halos-core-containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)