### PR TITLE
Exclude lintian-overrides from version-bump check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -165,6 +165,7 @@ jobs:
               | grep -v -E '^(tools/|run$|Makefile$|Taskfile\.yml$)' \
               | grep -v -E '^(store/)' \
               | grep -v -E '\.(lock)$' \
+              | grep -v -E '\.lintian-overrides$' \
               || true)
 
             if [ -n "$PACKAGE_FILES" ]; then


### PR DESCRIPTION
## Summary

- Exclude `.lintian-overrides` files from the version-bump-check in pr-checks.yml
- These are build validation metadata, not package content — they shouldn't require an upstream version bump

Triggered by cockpit-networkmanager-halos needing a lintian override for `initial-upload-closes-no-bugs` (a HaLOS-internal package, not a Debian archive upload).

## Test plan

- [ ] CI passes on this PR
- [ ] cockpit-networkmanager-halos PR #9 version-bump-check passes without a VERSION change

🤖 Generated with [Claude Code](https://claude.com/claude-code)