### PR TITLE
chore: migrate org references from hatlabs to halos-org

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,7 +36,7 @@ on:
       apt-repository:
         description: 'APT repository to dispatch to'
         required: false
-        default: 'hatlabs/apt.hatlabs.fi'
+        default: 'halos-org/apt.halos.fi'
         type: string
       version-file:
         description: 'Path to VERSION file'
@@ -332,11 +332,11 @@ jobs:
           To install this pre-release:
 
           \`\`\`bash
-          # Add Hat Labs repository (if not already added)
-          curl -fsSL https://apt.hatlabs.fi/hat-labs-apt-key.asc | sudo gpg --dearmor -o /usr/share/keyrings/hatlabs-apt-key.gpg
+          # Add HaLOS repository (if not already added)
+          curl -fsSL https://apt.halos.fi/halos-apt-key.asc | sudo gpg --dearmor -o /usr/share/keyrings/halos.gpg
 
           # Add unstable channel
-          echo "deb [signed-by=/usr/share/keyrings/hatlabs-apt-key.gpg] https://apt.hatlabs.fi unstable main" | sudo tee /etc/apt/sources.list.d/hatlabs-unstable.list
+          echo "deb [signed-by=/usr/share/keyrings/halos.gpg] https://apt.halos.fi trixie-unstable main" | sudo tee /etc/apt/sources.list.d/halos-unstable.list
 
           # Update and install
           sudo apt update
@@ -404,7 +404,7 @@ jobs:
 
           ### Installation
 
-          Available from [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi):
+          Available from [apt.halos.fi](https://apt.halos.fi):
 
           \`\`\`bash
           sudo apt update

--- a/.github/workflows/check-image-updates.yml
+++ b/.github/workflows/check-image-updates.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout shared scripts
         uses: actions/checkout@v4
         with:
-          repository: hatlabs/shared-workflows
+          repository: halos-org/shared-workflows
           ref: ${{ steps.wf-ref.outputs.ref }}
           path: .shared-workflows
           sparse-checkout: scripts

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -20,7 +20,7 @@ on:
       apt-repository:
         description: 'APT repository to dispatch to'
         required: false
-        default: 'hatlabs/apt.hatlabs.fi'
+        default: 'halos-org/apt.halos.fi'
         type: string
       # Version tag format: v{upstream}+{revision} (e.g., v0.2.0+1 or v1.0.7.2+1)
       version-pattern:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ on:
 
 jobs:
   checks:
-    uses: hatlabs/shared-workflows/.github/workflows/pr-checks.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/pr-checks.yml@main
 ```
 
 **Inputs:**
@@ -71,7 +71,7 @@ on:
 
 jobs:
   build-release:
-    uses: hatlabs/shared-workflows/.github/workflows/build-release.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/build-release.yml@main
     with:
       package-name: my-package
       package-description: 'Description for release notes'
@@ -123,7 +123,7 @@ on:
 
 jobs:
   publish:
-    uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/publish-stable.yml@main
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}
 ```

--- a/examples/cockpit-apt/.github/workflows/main.yml
+++ b/examples/cockpit-apt/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-release:
-    uses: hatlabs/shared-workflows/.github/workflows/build-release.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/build-release.yml@main
     with:
       package-name: cockpit-apt
       package-description: 'Modern Cockpit interface for APT package management on Debian'

--- a/examples/cockpit-apt/.github/workflows/pr.yml
+++ b/examples/cockpit-apt/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   checks:
-    uses: hatlabs/shared-workflows/.github/workflows/pr-checks.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/pr-checks.yml@main
     # Optional: override defaults
     # with:
     #   test-action: './.github/actions/run-tests'

--- a/examples/cockpit-apt/.github/workflows/release.yml
+++ b/examples/cockpit-apt/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/publish-stable.yml@main
     # Optional: override defaults
     # with:
     #   apt-distro: 'trixie'


### PR DESCRIPTION
## Summary

- Update all GitHub organization references from `hatlabs` to `halos-org` for transferred repositories
- CI workflow references, package metadata, documentation links, and other org-specific URLs

Part of the HaLOS org migration from `hatlabs` to `halos-org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)