### PR TITLE
Exclude config.* from version-bump-check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -161,7 +161,7 @@ jobs:
               | grep -v -E '^(VERSION$|.*\.md$|docs/|\.github/|\.devcontainer/|\.vscode/|\.claude/)' \
               | grep -v -E '^(lefthook\.yml$|\.bumpversion\.cfg$|\.gitignore$|\.editorconfig$|LICENSE)' \
               | grep -v -E '^(tests?/|__tests__/|e2e/|.*\.test\.[^/]+$|.*\.spec\.[^/]+$)' \
-              | grep -v -E '^(docker/|Dockerfile|docker-compose)' \
+              | grep -v -E '^(docker/|Dockerfile|docker-compose|config\.)' \
               | grep -v -E '^(tools/|run$|Makefile$|Taskfile\.yml$)' \
               | grep -v -E '^(store/)' \
               | grep -v -E '\.(lock)$' \


### PR DESCRIPTION
## Summary

- Add `config\.` to the build-config exclusion pattern in version-bump-check

## Motivation

Build configuration files like `config.halos-marine-halpi2` (used by pi-gen) are not package-affecting. They're analogous to `Dockerfile` and `docker-compose*` which are already excluded.

This was triggered by halos-org/halos-pi-gen#59 where renaming image filenames in config files caused a spurious version-bump-check failure.

## Test plan

- [ ] Merge this, then re-run checks on halos-org/halos-pi-gen#59

🤖 Generated with [Claude Code](https://claude.com/claude-code)