### PR TITLE
ci(version-bump-check): explain per-release-cycle rule in messages

### DIFF
--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -90,7 +90,7 @@ jobs:
               TAGGED_VERSION=$(echo "$LATEST_STABLE_TAG" | sed 's/^v\(.*\)+[0-9]*$/\1/')
 
               if [ "$CURRENT_VERSION" != "$TAGGED_VERSION" ]; then
-                echo "VERSION ($CURRENT_VERSION) differs from latest stable release ($TAGGED_VERSION) — no bump needed"
+                echo "::notice::VERSION ($CURRENT_VERSION) is already ahead of the latest stable release ($TAGGED_VERSION) — a prior PR opened the current release cycle, so this PR should NOT bump VERSION. The +N revision auto-increments on each merge."
               else
                 # VERSION matches latest stable tag — check if package-affecting files changed
                 PACKAGE_FILES=$(echo "$CHANGED_FILES" \
@@ -106,13 +106,13 @@ jobs:
                   || true)
 
                 if [ -n "$PACKAGE_FILES" ]; then
-                  echo "::error::Package-affecting files changed but VERSION ($CURRENT_VERSION) still matches the latest stable release ($LATEST_STABLE_TAG)."
+                  echo "::error::VERSION ($CURRENT_VERSION) matches the latest stable release ($LATEST_STABLE_TAG) and this PR changes package-affecting files — that means it opens a new release cycle, so VERSION must be bumped once here (or in a separate PR landed first)."
                   echo ""
                   echo "Changed package files:"
                   echo "$PACKAGE_FILES" | sed 's/^/  /'
                   echo ""
-                  echo "VERSION needs to be bumped before the next release."
-                  echo "Run './run bumpversion patch' (or minor/major) — either in this PR or a separate one."
+                  echo "Reminder: VERSION bumps are per release cycle, not per PR. Only the PR that opens a new cycle (this one) needs to bump; later feature PRs in the same cycle should NOT bump again — CI walks the +N revision automatically."
+                  echo "Run './run bumpversion patch' (or minor/major)."
                   FAILED=1
                 fi
               fi


### PR DESCRIPTION
## Summary

Update the human-readable output of the `version-bump-check` workflow so it matches the actual conditional rule it enforces:

- The "no bump needed" branch is now a `::notice::` that explicitly tells contributors NOT to bump `VERSION` when a prior PR has already opened the current release cycle.
- The error branch now says "this PR opens a new release cycle, so VERSION must be bumped once here" instead of the previous "needs to be bumped before the next release" wording that implied every package-touching PR needs to bump.

## Why

The workflow logic is already correct. Contributors were misreading the messages and bumping `VERSION` in every feature PR, which leaves gaps in the stable release history (see halos-org/halos#113 for the cross-repo data).

No behavior change — message text only.

## Test plan

- [ ] Workflow YAML syntactically valid (the only path that runs is shell `echo`, no logic changed).
- [ ] On a future PR that satisfies the no-bump branch, the GitHub Actions summary surfaces the `::notice::` banner.

Closes halos-org/halos#113