### PR TITLE
fix(version-bump-check): treat root docker-compose.yml as a package file

### DIFF
--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -92,13 +92,18 @@ jobs:
               if [ "$CURRENT_VERSION" != "$TAGGED_VERSION" ]; then
                 echo "::notice::VERSION ($CURRENT_VERSION) is already ahead of the latest stable release ($TAGGED_VERSION) — a prior PR opened the current release cycle, so this PR should NOT bump VERSION. The +N revision auto-increments on each merge."
               else
-                # VERSION matches latest stable tag — check if package-affecting files changed
+                # VERSION matches latest stable tag — check if package-affecting files changed.
+                # Note: root-level docker-compose.yml is NOT excluded — for container-app
+                # repos (halos-core-containers, halos-imported-containers, halos-marine-containers)
+                # the root compose file is the package payload (shipped via debian/rules). Nested
+                # dev/test compose files under docker/ or tests/ are still excluded via those
+                # directory patterns.
                 PACKAGE_FILES=$(echo "$CHANGED_FILES" \
                   | grep -v '^apps/' \
                   | grep -v -E '^(VERSION$|.*\.md$|docs/|\.github/|\.devcontainer/|\.vscode/|\.claude/)' \
                   | grep -v -E '^(lefthook\.yml$|\.bumpversion\.cfg$|\.gitignore$|\.editorconfig$|LICENSE)' \
                   | grep -v -E '^(tests?/|__tests__/|e2e/|.*\.test\.[^/]+$|.*\.spec\.[^/]+$)' \
-                  | grep -v -E '^(docker/|Dockerfile|docker-compose|config\.)' \
+                  | grep -v -E '^(docker/|Dockerfile|config\.)' \
                   | grep -v -E '^(tools/|run$|Makefile$|Taskfile\.yml$)' \
                   | grep -v -E '^(store/)' \
                   | grep -v -E '\.(lock)$' \


### PR DESCRIPTION
## Why

The exclude pattern in \`version-bump-check.yml\` had \`docker-compose\` in its list, which silently stripped root \`docker-compose.yml\` from the set of package-affecting files. For container-app repos under halos-org (\`halos-core-containers\`, \`halos-imported-containers\`, \`halos-marine-containers\`) the root compose file IS the deliverable — \`debian/rules\` installs it verbatim into \`/usr/lib/<pkg>/\` and \`prestart.sh\` consumes it at boot. A change to that file is a runtime behavior change for upgraded users and per the policy in [halos workspace AGENTS.md](https://github.com/halos-org/halos/blob/main/AGENTS.md) it must trigger a \`VERSION\` bump on the PR that opens the next release cycle.

## Concrete regression this would have caught

halos-org/halos-core-containers#151 removed \`NEXTAUTH_URL\` from \`docker-compose.yml\` — a real behavior change — without bumping \`VERSION\`. Even once \`pr-checks.yml\` is wired into that repo (separate follow-up PR), this exclude would have hidden the change and let it land as \`v0.4.0+2\` (semantically wrong: \`+N\` is a packaging revision, not a vehicle for source changes). PR halos-org/halos-core-containers#154 cleaned up by bumping to \`0.4.1\` after the fact, but the right time to catch it is at PR-check time.

## What

Removes \`docker-compose\` from the exclude regex in \`Part B: Repo-level VERSION check\`. Adds an inline comment explaining why root compose is treated as a package file.

Nested compose files under \`docker/\`, \`tests/\`, \`tests*/\` etc. remain excluded via the existing \`^docker/\` and \`^tests?/\` patterns — \`docker/dev-compose.yml\`, \`tests/docker-compose.test.yml\` and friends still don't trigger a bump.

## Scope

Behavior change for **any** repo using this reusable workflow that has a root-level \`docker-compose.yml\`. If a repo has one purely for dev tooling (not shipped), it will start seeing PR-check failures unless it either:

1. Moves the dev compose into \`docker/\` or \`tests/\`, or
2. Owns the omission and lands a \`VERSION\` bump.

A grep across the org isn't easily scriptable here without listing every repo, but the three container-app repos above are the known intentional shippers, and this is the right default for them.

## Test plan

- [ ] CI green
- [ ] After merge: re-verify against halos-core-containers#151's diff (simulated) — would now flag \`docker-compose.yml\` as a package file when VERSION matches latest stable.