### PR TITLE
fix(build-release): wrap generated changelog lines at 80 columns

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -167,13 +167,28 @@ jobs:
             URGENCY="medium"
             DATE=$(date -R)
 
+            # Fold commit subjects into changelog bullets wrapped at 80 columns.
+            # lintian's debian-changelog-line-too-long warning is fatal here
+            # (--fail-on warning), and conventional-commit subjects routinely
+            # exceed the limit once the "  * " prefix is added.
+            wrap_changes() {
+              while IFS= read -r subject; do
+                [ -z "$subject" ] && continue
+                printf '%s\n' "$subject" \
+                  | fold -s -w 76 \
+                  | sed -e 's/[[:space:]]*$//' -e '1s/^/  * /' -e '1!s/^/    /'
+              done
+            }
+
             # Get recent changes from git log
             LAST_TAG=$(git tag -l "v*" --sort=-version:refname | grep -v "_pre" | head -n1 || echo "")
 
+            # tformat (not format) terminates every subject with a newline so
+            # the read loop in wrap_changes does not drop the last commit.
             if [ -n "$LAST_TAG" ]; then
-              CHANGES=$(git log "${LAST_TAG}"..HEAD --pretty=format:"  * %s" --no-merges -- || echo "  * Build ${REVISION}")
+              CHANGES=$(git log "${LAST_TAG}"..HEAD --pretty=tformat:"%s" --no-merges -- | wrap_changes)
             else
-              CHANGES=$(git log -10 --pretty=format:"  * %s" --no-merges || echo "  * Build ${REVISION}")
+              CHANGES=$(git log -10 --pretty=tformat:"%s" --no-merges | wrap_changes)
             fi
 
             if [ -z "$CHANGES" ]; then


### PR DESCRIPTION
## Why

`build-release.yml` generates `debian/changelog` from git commit subjects prefixed with `  * `, then gates the build on `lintian --fail-on error,warning`. Any commit subject longer than ~76 chars produces a line over 80 columns, tripping the cosmetic `debian-changelog-line-too-long` warning — which is fatal here. Conventional-commit subjects routinely exceed that, silently breaking releases for consumer repos.

Real impact: `halos-cockpit-config` main CI was red from 2026-05-25 onward on an 83-col line (`fix(agents): replace remaining workspace + shared-workflows refs with full URLs`). No release built for ~10 days; a merged dashboard layout fix never reached apt and kept shipping the old layout in images.

## How

Fold each commit subject at 76 columns (`fold -s`) with a 4-space continuation indent, so the `  * ` / `    ` prefix keeps every line ≤ 80. This is Option 1 from the issue: keeps the lintian gate strict and removes the need for per-repo `debian-changelog-line-too-long` overrides.

Only the `debian/changelog` generation is touched. The GitHub-release-body changelogs don't pass through lintian, so they're left alone. The existing `[ -z "$CHANGES" ]` fallback still handles the empty-log case.

## Verification

Tested the wrapping against the acceptance cases locally:

| Input | Result |
|---|---|
| The exact 83-col line that broke halos-cockpit-config | wraps → 78 + 8 cols |
| A ~100-char subject | wraps → 78 + 30 cols |
| A spaceless 97-char URL | hard-breaks → 80 + 25 cols |

End-to-end simulation (heredoc + existing `sed` indent-strip) produces a valid changelog with max line length 78.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)