### PR TITLE
fix: follow GHCR pagination when fetching tags, not just the first page

### DIFF
--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -64,7 +64,15 @@ print('^' + pat + r'$')
 " "$1"
 }
 
-# Fetch all tags from Docker Hub or GHCR.
+# Fetch all tags from Docker Hub or GHCR, following pagination fully — a
+# tag-heavy image (e.g. home-assistant/home-assistant, years of near-daily
+# CalVer releases) exceeds a single page, and the registry silently caps the
+# page size below whatever we ask for rather than erroring. Missing pages
+# means missing the actual latest tag: GHCR returns tags in lexicographic
+# order, so a truncated first page still returns a full page of
+# early-sorting tags and just silently drops everything after, which for
+# home-assistant produced a "latest" from ~2023 while 2026.x releases existed
+# unseen past the cutoff.
 fetch_tags() {
   local image=$1
   if [[ $image == ghcr.io/* ]]; then
@@ -72,17 +80,30 @@ fetch_tags() {
     local token
     token=$(curl -fsSL "https://ghcr.io/token?scope=repository:${repo}:pull" \
       | python3 -c "import sys,json;print(json.load(sys.stdin)['token'])")
-    # n=10000: OCI tags/list defaults to ~100 in lex order which misses
-    # high-numbered versions (e.g., v1.51.0 sorts after v1.9.0)
-    curl -fsSL -H "Authorization: Bearer $token" \
-      "https://ghcr.io/v2/${repo}/tags/list?n=10000" \
-      | python3 -c "import sys,json;[print(t) for t in json.load(sys.stdin).get('tags',[])]"
+    # n=10000 is a request, not a guarantee: GHCR has been observed capping
+    # actual responses at 1000 regardless. Follow the Link: rel="next"
+    # header (RFC 8288, relative-path style) until it's absent.
+    local path="/v2/${repo}/tags/list?n=10000"
+    local headers
+    while [ -n "$path" ]; do
+      headers=$(mktemp)
+      curl -fsSL -D "$headers" -H "Authorization: Bearer $token" \
+        "https://ghcr.io${path}" \
+        | python3 -c "import sys,json;[print(t) for t in json.load(sys.stdin).get('tags',[])]"
+      path=$(tr -d '\r' < "$headers" | grep -i '^link:' \
+        | sed -nE 's/.*<([^>]*)>; *rel="next".*/\1/p')
+      rm -f "$headers"
+    done
   else
     local path=$image
     [[ $image != */* ]] && path="library/$image"
-    curl -fsSL \
-      "https://hub.docker.com/v2/repositories/${path}/tags?page_size=100&ordering=last_updated" \
-      | python3 -c "import sys,json;[print(r['name']) for r in json.load(sys.stdin).get('results',[])]"
+    local url="https://hub.docker.com/v2/repositories/${path}/tags?page_size=100&ordering=last_updated"
+    while [ -n "$url" ] && [ "$url" != "null" ]; do
+      local response
+      response=$(curl -fsSL "$url")
+      echo "$response" | python3 -c "import sys,json;[print(r['name']) for r in json.load(sys.stdin).get('results',[])]"
+      url=$(echo "$response" | python3 -c "import sys,json;print(json.load(sys.stdin).get('next') or '')")
+    done
   fi
 }
 


### PR DESCRIPTION
## Summary

`fetch_tags()`'s GHCR branch requests `n=10000` but never follows the registry's `Link: rel="next"` pagination header — it just takes whatever the first response contains. GHCR silently caps the actual page size below the requested `n` for tag-heavy images, so any image with more tags than that cap loses everything past the first page, with no error or warning.

## How this was found

`check-image-updates.sh` produced a PR against a downstream repo proposing to change `ghcr.io/home-assistant/home-assistant` from `2026.7.0` (the live-running version) to `2023.3.6` — a 3+ year downgrade masquerading as an "update".

Confirmed directly against the registry:

```
$ curl -s -D - -o /dev/null -H "Authorization: Bearer $TOKEN" \
    "https://ghcr.io/v2/home-assistant/home-assistant/tags/list?n=10000" | grep -i link
link: </v2/home-assistant/home-assistant/tags/list?last=2023.4.0b2&n=10000>; rel="next"
```

Despite requesting `n=10000`, GHCR returned exactly 1000 tags and a `Link` header pointing at the rest. Tags come back in lexicographic order, so this isn't a random subset — it's a full page of the earliest-sorting tags (up to `2023.4.0b2`) with a hard stop, and `2026.x` releases exist entirely past that cutoff, unseen.

## Fix

- GHCR: follow `Link: rel="next"` in a loop until absent, accumulating tags across all pages.
- Docker Hub: same class of bug existed (the response's `next` field was ignored) — hardened the same way, though I haven't observed it bite in practice since that endpoint orders by `last_updated` rather than lexicographically. Same silent-truncation risk for any image with enough tags, though.

## Tested

Extracted `fetch_tags()` and ran it directly against the real registries:

- `ghcr.io/home-assistant/home-assistant`: now returns 4327 tags (vs. 1000 before), correctly including `2026.7.0`, `2026.7.1`, `2026.7.2`
- Ran the full script end-to-end against a throwaway compose fixture with `homeassistant:2026.7.0` as the "current" tag: now correctly computes `Latest: 2026.7.2` (previously would have computed `2023.3.6`, per the actual downstream PR this surfaced from)
- `ghcr.io/music-assistant/server` (small image, genuinely single page, no `Link` header): unaffected, no regression — loop terminates immediately as before

Did not modify `tag_pattern()` or the `sort -V` comparison logic — those were already correct; the only issue was the tag list being incomplete before it ever reached them.