### PR TITLE
Never let the update bot repin an image we publish ourselves

### DIFF
--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -22,8 +22,19 @@ python3 -c "import yaml" 2>/dev/null || pip install --quiet --break-system-packa
 # Parse images from compose files
 # ---------------------------------------------------------------------------
 
+# Images we publish ourselves are skipped. They live in their own repo so a
+# person reads what changed in the curated contents before it reaches a boat,
+# and a daily cron repinning them on a tag match walks straight past that. Their
+# tags also carry a build revision this script cannot split from the upstream
+# version: `2.30.0-1` yields `version: 2.30.0-2-1` and an `upstream_version` of
+# `2.30.0-2`, which is our build revision, not anything upstream released.
+SELF_BUILT_PREFIXES="${SELF_BUILT_PREFIXES:-ghcr.io/halos-org/ ghcr.io/hatlabs/}"
+export SELF_BUILT_PREFIXES
+
 IMAGES=$(python3 << 'PYEOF'
-import yaml, os, glob
+import sys, yaml, os, glob
+
+prefixes = tuple(os.environ["SELF_BUILT_PREFIXES"].split())
 
 for f in sorted(glob.glob(os.environ["COMPOSE_PATTERN"], recursive=True)):
     with open(f) as fh:
@@ -32,9 +43,14 @@ for f in sorted(glob.glob(os.environ["COMPOSE_PATTERN"], recursive=True)):
         continue
     for name, svc in data.get("services", {}).items():
         img = svc.get("image", "")
-        if ":" in img:
-            ref, tag = img.rsplit(":", 1)
-            print(f"{f}|{name}|{ref}|{tag}")
+        if ":" not in img:
+            continue
+        ref, tag = img.rsplit(":", 1)
+        if ref.startswith(prefixes):
+            print(f"SKIP {f} {ref}: we publish this one; repin it by hand",
+                  file=sys.stderr)
+            continue
+        print(f"{f}|{name}|{ref}|{tag}")
 PYEOF
 )
 


### PR DESCRIPTION
Fixes the mechanism behind halos-org/halos-marine-containers#212.

## The problem

`check-image-updates.sh` derives its tag pattern from the tag currently pinned. A curated image at `2.30.0-1` yields `^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$`, which matches every tag that image will ever publish. On a match it rewrites the compose file and sets `new_meta_ver="${stripped_tag}-1"`, producing:

```yaml
version: 2.30.0-2-1
upstream_version: 2.30.0-2
```

`2.30.0-2` is our build revision, not an upstream release, and `2.30.0-2-1` is not a valid `<upstream>-<revision>`. The old `v2.30.0-core` tag would have mangled it too, but visibly — `2.30.0-2-1` reads as plausible and gets merged.

The mangling is the smaller half. These images live in a separate repo so a person reads what changed in the curated contents before it reaches a boat. A daily cron repinning on a tag match bypasses that, and version-bump CI stays green because the bot bumped `metadata.yaml` itself.

## The fix

Skip images under our own org prefixes, and say so on stderr. The rule is derived rather than a maintained exclusion list, so a curated image added later is covered without anyone remembering. `SELF_BUILT_PREFIXES` overrides it if a repo ever needs different behaviour.

## Verification

Ran the enumeration against `halos-marine-containers/apps/*/docker-compose.yml`:

```
SKIPPED (ours, repin by hand):
    ghcr.io/halos-org/opencpn-docker:5.12.4
    ghcr.io/halos-org/signalk-server-docker:2.30.0-1
STILL CHECKED (upstream): 3
    xfreex/avnav-stable:20251028
    grafana/grafana:13.1.0
    influxdb:2.9.1
```

opencpn is caught too. It was exposed to the same review bypass — its tag is a plain semver so the metadata would not have mangled, but the bot would still have repinned our own image on a cron.

Blast radius: `halos-core-containers` and `halos-marine-containers` are the only consumers, and core has no org-owned images, so this is a no-op there.

Worth stating plainly: this repo has no test harness, so the check above is an empirical run rather than a regression test. Adding one is a separate change and I did not want to introduce a framework as a side effect of a 20-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaZt172ZLjpyvzk6JYX9ts