### PR TITLE
Split our own image tags on -halos. before writing app metadata

### DIFF
--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -127,8 +127,6 @@ while IFS='|' read -r file service image current_tag; do
     app_dir=$(dirname "$file")
     metadata="$app_dir/metadata.yaml"
     if [ -f "$metadata" ] && [[ "$BUMPED_METADATA" != *"|$metadata|"* ]]; then
-      stripped_tag="${latest#v}"
-      new_meta_ver="${stripped_tag}-1"
       old_meta_ver=$(python3 -c "
 import yaml, sys
 d = yaml.safe_load(open(sys.argv[1]))
@@ -136,8 +134,25 @@ v = d.get('version')
 if v is None: sys.exit(1)
 print(v)
 " "$metadata") || { echo "  metadata.yaml: no version field, skipping"; continue; }
+
+      # Images we build tag as `v<upstream>-halos.<build>`; everything else
+      # carries upstream's own version. Without the split our build revision
+      # lands in upstream_version, which is defined as what upstream released.
+      stripped_tag="${latest#v}"
+      new_upstream="${stripped_tag%%-halos.*}"
+
+      # The app's package revision restarts at 1 on a new upstream version and
+      # advances otherwise -- a new build of the same upstream still has to sort
+      # above the last one, and resetting to 1 would sort below it.
+      old_upstream="${old_meta_ver%-*}"
+      old_rev="${old_meta_ver##*-}"
+      if [ "$new_upstream" = "$old_upstream" ] && [[ "$old_rev" =~ ^[0-9]+$ ]]; then
+        new_meta_ver="${new_upstream}-$((old_rev + 1))"
+      else
+        new_meta_ver="${new_upstream}-1"
+      fi
       # Update version and upstream_version, preserving any YAML quoting style
-      python3 - "$metadata" "$new_meta_ver" "$stripped_tag" << 'PYEOF'
+      python3 - "$metadata" "$new_meta_ver" "$new_upstream" << 'PYEOF'
 import sys
 path, new_ver, new_upstream = sys.argv[1:]
 lines = []


### PR DESCRIPTION
Closes halos-org/halos-marine-containers#212.

## The bug

`check-image-updates.sh` derived the upstream version by stripping a leading `v` and taking the rest:

```bash
stripped_tag="${latest#v}"
new_meta_ver="${stripped_tag}-1"
# writes version: $new_meta_ver, upstream_version: $stripped_tag
```

Correct for an image tagged with upstream's own version. Wrong for one we build. Fed `v2.30.0-halos.2` it wrote `upstream_version: 2.30.0-halos.2` — our build revision recorded as an upstream release — and `version: 2.30.0-halos.2-1`, which is not a valid `<upstream>-<revision>`.

Now that halos-org/signalk-server-docker#4 has landed, both of our curated images publish `v<upstream>-halos.<n>`, so one split covers them.

## The package revision

Splitting alone is not enough. The revision was reset to `1` on every repin, which is right when upstream's version moves and wrong when only our build revision does — `v2.30.0-halos.2` and `v2.30.0-halos.3` would both write `version: 2.30.0-1`, and the second would not sort above the first. Debian versions have to increase.

It now advances when the upstream half is unchanged and restarts when it moves.

## Verification

Eight cases through the exact shipped logic:

```
--- ours: build revision advances, upstream unchanged ---
ok     v2.30.0-halos.3      old=2.30.0-5     -> version=2.30.0-6     upstream=2.30.0
ok     v2.30.0-halos.10     old=2.30.0-6     -> version=2.30.0-7     upstream=2.30.0
--- ours: upstream bump resets the package revision ---
ok     v2.31.0-halos.1      old=2.30.0-5     -> version=2.31.0-1     upstream=2.31.0
--- upstream images: unchanged behaviour ---
ok     v3.7.10              old=3.7.1-1      -> version=3.7.10-1     upstream=3.7.10
ok     4.39.20              old=4.39.19-1    -> version=4.39.20-1    upstream=4.39.20
ok     9.1.1-alpine         old=9.0.4-alpine-1 -> version=9.1.1-alpine-1 upstream=9.1.1-alpine
--- homarr: the other -halos. image ---
ok     v1.60.0-halos.2      old=1.60.0-1     -> version=1.60.0-2     upstream=1.60.0
--- degenerate old metadata ---
ok     v2.30.0-halos.3      old=2.30.0       -> version=2.30.0-1     upstream=2.30.0
```

Images tagged with upstream's own version are provably unaffected: the upstream half is the whole tag, so a repin always sees a different one and takes the restart branch. The advance branch can only fire for a `-halos.` tag.

## Scope

This does **not** re-litigate whether the bot should repin our images. It should — an image we tagged is a deliberate release. shared-workflows#33 tried exempting them and was closed; blocking the delivery path removed the only signal that a new build exists.

Landing order matters and this is the first step. halos-org/halos-marine-containers#218 repins the marine app afterwards; doing it in the other order lets the next cron write the corruption before the parser exists.

## What is still missing

No test, and no way to add a running one: every workflow here is `workflow_call`-only, so this repo has no CI on its own PRs. The table above is a hand-run against the shipped logic, not a regression test — a later edit to this derivation fails silently. That gap is recorded in #34 along with four other pre-existing defects.

The `dry-run` input on `check-image-updates.yml` is the available end-to-end check: point a consumer's `uses:` at this branch and dispatch it. Worth doing against halos-core-containers before merge, since homarr exercises the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaZt172ZLjpyvzk6JYX9ts