### PR TITLE
Take the shared scripts from this workflow's own commit

### DIFF
--- a/.github/workflows/check-image-updates.yml
+++ b/.github/workflows/check-image-updates.yml
@@ -39,19 +39,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # github.workflow_ref = "owner/repo/path@refs/heads/branch" — extract the ref
-      # after @ so the scripts checkout matches whichever version the caller pinned.
-      - name: Resolve shared workflow ref
-        id: wf-ref
-        run: echo "ref=${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-
+      # job_workflow_sha is the commit of *this* reusable workflow file, so the
+      # scripts come from the same revision the caller pinned. github.workflow_ref
+      # names the calling workflow instead, which resolves against the wrong repo
+      # and only appeared to work because both sides have a `main`.
       - name: Checkout shared scripts
         uses: actions/checkout@v4
         with:
           repository: halos-org/shared-workflows
-          ref: ${{ steps.wf-ref.outputs.ref }}
+          ref: ${{ github.job_workflow_sha }}
           path: .shared-workflows
           sparse-checkout: scripts
 


### PR DESCRIPTION
Refs #34.

## The bug

```yaml
- name: Resolve shared workflow ref
  run: echo "ref=${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
  env:
    WORKFLOW_REF: ${{ github.workflow_ref }}
```

The comment says this makes "the scripts checkout match whichever version the caller pinned". It does not. Inside a reusable workflow `github.workflow_ref` names the **calling** workflow, so the extracted ref is the caller's branch — then used to check out `halos-org/shared-workflows` at that ref.

It only ever worked because every caller pins `@main` and both repos have a `main`.

Demonstrated while trying to dry-run #35 from a branch:

```
##[error]fatal: couldn't find remote ref refs/heads/test/halos-split-dryrun
```

`test/halos-split-dryrun` was a branch in `halos-core-containers`. The job went looking for it in `shared-workflows`.

Two consequences. Any caller running this workflow from a non-`main` branch fails outright — which also means the `dry-run` input, the only pre-merge verification this repo has, cannot be used to test a change to these scripts. And a caller pinning a tag would silently get whatever the caller's own ref resolves to rather than the pinned revision.

## The fix

`github.job_workflow_sha` is the commit of the reusable workflow file actually being run, which is exactly what the scripts have to match. No parsing, and it fails loudly rather than silently if the hardcoded `repository:` is ever wrong, since a SHA will not resolve in two different repos.

## Verification

Dry-run dispatched from a `halos-core-containers` branch pinning this branch: [run 31201516950](https://github.com/halos-org/halos-core-containers/actions/runs/31201516950), `completed success`. The same setup against `main`'s version of this workflow failed at "Checkout shared scripts".

The run also exercised the real image checks — traefik, authelia, valkey and homarr all resolved and reported updates correctly — so the scripts checked out are the right ones.

Worth noting the run surfaced `metadata.yaml: no version field, skipping` for every image, because `halos-core-containers` has no per-app metadata. That is expected there, and it is why #35 needed separate verification against a fixture that has one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaZt172ZLjpyvzk6JYX9ts