### PR TITLE
test: probe the event guard expression

### DIFF
--- a/.github/workflows/guardprobe.yml
+++ b/.github/workflows/guardprobe.yml
@@ -1,0 +1,18 @@
+name: Guard Probe
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse an event this gate cannot judge
+        if: >-
+          github.event_name != 'pull_request'
+          && github.event_name != 'push'
+          && github.event_name != 'workflow_dispatch'
+        run: |
+          echo "GUARD FIRED on ${{ github.event_name }}" >&2
+          exit 1
+      - name: Reached the real work
+        run: echo "guard did not fire on ${{ github.event_name }}"


### PR DESCRIPTION
Throwaway. Confirms the guard step skips on pull_request. Closed once observed.