### PR TITLE
Let a caller own the name of its required check

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,14 @@ update needs. Catching a stamp-only diff is a reviewer's job.
 
 **Making it a gate.** Nothing here makes the check required; that is a branch
 protection rule in the consuming repository. The check is named `<your job id> /
-translation-status`. Two things to know before enabling it: the example
-deliberately carries no `paths` filter, because a required check that never runs
-on a PR touching none of the filtered paths leaves that PR unmergeable forever;
+translation-status`, which is a name a caller cannot choose freely: a
+reusable-workflow call always reports as `<caller job> / <called job>`. A
+repository that already requires some other context, or that would rather not
+tie its protection to a job name in this repository, can carry the name on a
+job of its own that depends on this one — see the caller example. Two more
+things to know before enabling it: the example deliberately carries no `paths`
+filter, because a required check that never runs on a PR touching none of the
+filtered paths leaves that PR unmergeable forever;
 and the gate reads the repository as it stood when the run started, so two
 independently green PRs can merge into a stale `main`. Require branches to be up
 to date before merging, or use a merge queue — which needs a `merge_group`

--- a/examples/docs-repo/.github/workflows/translation-status.yml
+++ b/examples/docs-repo/.github/workflows/translation-status.yml
@@ -26,3 +26,18 @@ concurrency:
 jobs:
   translation-status:
     uses: halos-org/shared-workflows/.github/workflows/translation-status.yml@main
+
+  # A reusable-workflow call reports as `<caller job> / <called job>`, so the
+  # check name is not the caller's to choose and changes if the called job is
+  # ever renamed. Carrying the required context on a plain job of your own
+  # decouples branch protection from both. Drop this job if you would rather
+  # require `translation-status / translation-status` directly.
+  status:
+    needs: translation-status
+    # always(), or a failed gate leaves this skipped, and a skipped required
+    # check never reports either. GitHub waits on a required context forever.
+    if: always()
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - run: '[ "${{ needs.translation-status.result }}" = "success" ]'


### PR DESCRIPTION
A reusable-workflow call reports as `<caller job> / <called job>`, so the check name is not the caller's to choose, and it moves if the called job is ever renamed. A repository adopting this workflow therefore renames the context its branch protection already requires — and a required context that nothing reports blocks every pull request forever, with no admin override under `enforce_admins`.

Not hypothetical. `hatlabs/halpi2`, `hatlabs/halmet` and `hatlabs/sh-rpi` each require a context named `status`, which is the job name in the workflow they are replacing:

```
$ gh api repos/hatlabs/halpi2/branches/main/protection
{"contexts": ["status"], "strict": true, "enforce_admins": true}

$ gh api repos/hatlabs/halpi2/commits/<pr head>/check-runs
translation-status / translation-status: success
```

The caller example gains an optional job carrying the name and depending on the gate, and the README says why a repository might want it. Verified both directions on halpi2: it reports `status` and passes in 3s, and on a branch with a deliberately failing gate both the called job and this one came back red — an aggregator that always passes would be worse than no check.

**Scope note.** This PR started as `--since` wiring, to gate `stale` only on the English pages a change touched. That is dropped. Blocking a documentation pull request while its translations are stale is the intended behaviour, and the case `--since` actually relieves is narrower than it first appeared: it does *not* excuse a page the change edits, only pages it did not touch. `hatlabs/halpi2`'s `main` measures clean — all nine locales at 20 current, zero stale — and the drift window closes once the gate is required, so the flag would have been guarding a state the repository is not in.

`halos-docs-tools` v0.2.0 still carries `--since` if it is ever wanted; nothing here uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status job that provides a stable, repository-controlled check for branch protection.
  * The status check runs even when the translation check fails and reflects its result.

* **Documentation**
  * Clarified how check names are generated for reusable workflows.
  * Added guidance on using a dependent repository job to control the check name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->